### PR TITLE
Provide the option to not to log via STDERR

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,6 +40,7 @@ Following is the example of multus config file, in `/etc/cni/net.d/`.
 * `cniDir` (string, optional): Multus CNI data directory, default `/var/lib/cni/multus`
 * `binDir` (string, optional): additional directory for CNI plugins which multus calls, in addition to the default (the default is typically set to `/opt/cni/bin`)
 * `kubeconfig` (string, optional): kubeconfig file for the out of cluster communication with kube-apiserver. See the example [kubeconfig](https://github.com/intel/multus-cni/blob/master/doc/node-kubeconfig.yaml). If you would like to use CRD (i.e. network attachment definition), this is required
+* `logToStderr` (bool, optional): Enable or disable logging to `STDERR`. Defaults to true.
 * `logFile` (string, optional): file path for log file. multus puts log in given file
 * `logLevel` (string, optional): logging level ("debug", "error", "verbose", or "panic")
 * `namespaceIsolation` (boolean, optional): Enables a security feature where pods are only allowed to access `NetworkAttachmentDefinitions` in the namespace where the pod resides. Defaults to false.
@@ -84,7 +85,15 @@ Only one option is necessary to configure this functionality:
 
 You may wish to enable some enhanced logging for Multus, especially during the process where you're configuring Multus and need to understand what is or isn't working with your particular configuration.
 
-Multus will always log via `STDERR`, which is the standard method by which CNI plugins communicate errors, and these errors are logged by the Kubelet. This method is always enabled.
+#### Logging via STDERR
+
+By default, Multus will log via `STDERR`, which is the standard method by which CNI plugins communicate errors, and these errors are logged by the Kubelet.
+
+Optionally, you may disable this method by setting the `logToStderr` option in your CNI configuration:
+
+```
+    "logToStderr": false,
+```
 
 #### Writing to a Log File
 

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -20,6 +20,7 @@ MULTUS_BIN_FILE="/usr/src/multus-cni/bin/multus"
 MULTUS_KUBECONFIG_FILE_HOST="/etc/cni/net.d/multus.d/multus.kubeconfig"
 MULTUS_NAMESPACE_ISOLATION=false
 MULTUS_GLOBAL_NAMESPACES=""
+MULTUS_LOG_TO_STDERR=true
 MULTUS_LOG_LEVEL=""
 MULTUS_LOG_FILE=""
 MULTUS_READINESS_INDICATOR_FILE=""
@@ -52,6 +53,7 @@ function usage()
     echo -e "\t--namespace-isolation=$MULTUS_NAMESPACE_ISOLATION"
     echo -e "\t--global-namespaces=$MULTUS_GLOBAL_NAMESPACES (used only with --namespace-isolation=true)"
     echo -e "\t--multus-autoconfig-dir=$MULTUS_AUTOCONF_DIR (used only with --multus-conf-file=auto)"
+    echo -e "\t--multus-log-to-stderr=$MULTUS_LOG_TO_STDERR (empty by default, used only with --multus-conf-file=auto)"
     echo -e "\t--multus-log-level=$MULTUS_LOG_LEVEL (empty by default, used only with --multus-conf-file=auto)"
     echo -e "\t--multus-log-file=$MULTUS_LOG_FILE (empty by default, used only with --multus-conf-file=auto)"
     echo -e "\t--override-network-name=false (used only with --multus-conf-file=auto)"
@@ -113,6 +115,9 @@ while [ "$1" != "" ]; do
             ;;
         --global-namespaces)
             MULTUS_GLOBAL_NAMESPACES=$VALUE
+            ;;
+        --multus-log-to-stderr)
+            MULTUS_LOG_TO_STDERR=$VALUE
             ;;
         --multus-log-level)
             MULTUS_LOG_LEVEL=$VALUE
@@ -276,6 +281,12 @@ if [ "$MULTUS_CONF_FILE" == "auto" ]; then
         GLOBAL_NAMESPACES_STRING="\"globalNamespaces\": \"$MULTUS_GLOBAL_NAMESPACES\","
       fi
 
+      LOG_TO_STDERR_STRING=""
+      if [ "$MULTUS_LOG_TO_STDERR" == false ]; then
+        LOG_TO_STDERR_STRING="\"logToStderr\": false,"
+      fi
+
+
       LOG_LEVEL_STRING=""
       if [ ! -z "${MULTUS_LOG_LEVEL// }" ]; then
         case "$MULTUS_LOG_LEVEL" in
@@ -355,6 +366,7 @@ EOF
           $NESTED_CAPABILITIES_STRING
           $ISOLATION_STRING
           $GLOBAL_NAMESPACES_STRING
+          $LOG_TO_STDERR_STRING
           $LOG_LEVEL_STRING
           $LOG_FILE_STRING
           $ADDITIONAL_BIN_DIR_STRING

--- a/pkg/types/conf.go
+++ b/pkg/types/conf.go
@@ -257,7 +257,8 @@ func GetGatewayFromResult(result *current.Result) []net.IP {
 
 // LoadNetConf converts inputs (i.e. stdin) to NetConf
 func LoadNetConf(bytes []byte) (*NetConf, error) {
-	netconf := &NetConf{}
+	// LogToStderr's default value set to true
+	netconf := &NetConf{LogToStderr: true}
 
 	logging.Debugf("LoadNetConf: %s", string(bytes))
 	if err := json.Unmarshal(bytes, netconf); err != nil {
@@ -265,6 +266,7 @@ func LoadNetConf(bytes []byte) (*NetConf, error) {
 	}
 
 	// Logging
+	logging.SetLogStderr(netconf.LogToStderr)
 	if netconf.LogFile != "" {
 		logging.SetLogFile(netconf.LogFile)
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -43,6 +43,7 @@ type NetConf struct {
 	DefaultNetworks []string                 `json:"defaultNetworks"`
 	LogFile         string                   `json:"logFile"`
 	LogLevel        string                   `json:"logLevel"`
+	LogToStderr     bool                     `json:"logToStderr,omitempty"`
 	RuntimeConfig   *RuntimeConfig           `json:"runtimeConfig,omitempty"`
 	// Default network readiness options
 	ReadinessIndicatorFile string `json:"readinessindicatorfile"`


### PR DESCRIPTION
Today, Multus will always log via STDERR, and these logs will then
logged by the Kubelet. If we also choose to have Multus log to a file by
setting the LogFile option in the CNI configuration, the same logs will
be logged twice.

This commit provide the option to disable logging to STDERR.

Signed-off-by: Yun Zhou <yunz@nvidia.com>